### PR TITLE
Adiciona Dockerfile e sistema de build com CMake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:latest AS build
+
+RUN apk add --no-cache \
+    alpine-sdk \ 
+    cmake \
+    gfortran
+
+COPY code /code
+
+WORKDIR /build
+
+RUN cmake /code && cmake --build . && cmake --install .
+
+FROM alpine:latest
+
+COPY --from=build /usr/local/bin/cmop /usr/bin/
+COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/
+COPY --from=build /usr/lib/libgfortran.so.5 /usr/lib/
+COPY --from=build /usr/lib/libquadmath.so.0 /usr/lib/
+COPY --from=build /lib/ld-musl-x86_64.so.1 /lib/
+
+WORKDIR /run
+
+CMD ["cmop"]

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,0 +1,28 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
+
+PROJECT(CMOP Fortran)
+
+SET(VERSION 0.0.1)
+
+SET(CMOP_exe cmop)
+SET(CMOP_src coupling.f90
+             datetime_module.f90
+             delft2oil.f90
+             dissolve_part.f90
+             dissolved_fase_mod.f90
+             era5_2_oil.f90
+             evaporation.f90
+             lagrange_continuo_new_time_loop.f90
+             linear_interpolation.f90
+             oil_fractions.f90
+             processes.f90
+             r8lib.f90
+             random_variables.f90
+             vertical_dispersion.f90
+             wind_variables.f90
+             white_space.f90
+)
+
+ADD_EXECUTABLE(${CMOP_exe} ${CMOP_src})
+
+INSTALL(TARGETS ${CMOP_exe} DESTINATION bin)


### PR DESCRIPTION
Adicionei um `CMakeLists.txt` para compilar de forma mais automática usando o [CMake](https://cmake.org/).

Também coloquei um Dockerfile para criar uma imagem com o CMOP já compilado e pronto para rodar (desde que os arquivos de input estejam OK).